### PR TITLE
Ability to passthrough custom datepicker arguments

### DIFF
--- a/src/jquery.jeditable.datepicker.js
+++ b/src/jquery.jeditable.datepicker.js
@@ -36,8 +36,8 @@ $.editable.addInputType( 'datepicker', {
 
       // Don't cancel inline editing onblur to allow clicking datepicker
       settings.onblur = 'nothing';
-      
-      input.datepicker( {
+
+      datepicker = {
         onSelect: function() {
           // clicking specific day in the calendar should
           // submit the form and close the input field
@@ -63,6 +63,12 @@ $.editable.addInputType( 'datepicker', {
             // without a delay the form is submitted in all scenarios, which is wrong
           }, 150 );
         }
-      } );
+      };
+    
+      if (settings.datepicker) {
+        jQuery.extend(datepicker, settings.datepicker);
+      }
+
+      input.datepicker(datepicker);
     }
 } );

--- a/test/javascripts/example.js
+++ b/test/javascripts/example.js
@@ -7,7 +7,11 @@ $( document ).ready( function() {
       date.html( value );
     },
     {
-      type: 'datepicker'
+      type: 'datepicker',
+      datepicker: {
+        changeMonth: true,
+        changeYear: true
+      }
     }
   );
 

--- a/test/javascripts/jquery.jeditable.datepicker.js
+++ b/test/javascripts/jquery.jeditable.datepicker.js
@@ -36,8 +36,8 @@ $.editable.addInputType( 'datepicker', {
 
       // Don't cancel inline editing onblur to allow clicking datepicker
       settings.onblur = 'nothing';
-      
-      input.datepicker( {
+
+      datepicker = {
         onSelect: function() {
           // clicking specific day in the calendar should
           // submit the form and close the input field
@@ -63,6 +63,12 @@ $.editable.addInputType( 'datepicker', {
             // without a delay the form is submitted in all scenarios, which is wrong
           }, 150 );
         }
-      } );
+      };
+    
+      if (settings.datepicker) {
+        jQuery.extend(datepicker, settings.datepicker);
+      }
+
+      input.datepicker(datepicker);
     }
 } );


### PR DESCRIPTION
Hi there!

Thanks for a great little plugin, I was about to write exactly the same thing until I spotted it already existed. I needed the ability to customize the datepicker generated when using an inline editable date field, so I added the ability to be able to passthrough custom arguments to the datepicker.

I also updated the test/demo page to showcase this, by making the demo datepicker include the month/year dropdown fields.

If you want me to write up anything for the README to explain this functionality, then let me know. Any other questions, then just shout!

Thanks again,
Elliott
